### PR TITLE
Fixes for OData options causing errors in some instances

### DIFF
--- a/OData/src/System.Web.Http.OData/OData/Query/OrderByQueryOption.cs
+++ b/OData/src/System.Web.Http.OData/OData/Query/OrderByQueryOption.cs
@@ -293,6 +293,8 @@ namespace System.Web.Http.OData.Query
                     }
                     else
                     {
+                        var translator = new ExpressionTranslator<TSource, TDestination>(_queryTranslator);
+                        property = translator.TranslateProperty(property);
                         querySoFar = ExpressionHelpers.OrderByProperty(querySoFar, property, direction, typeof(TSource), alreadyOrdered) as IQueryable<TSource>;
                     }
                     alreadyOrdered = true;

--- a/OData/src/System.Web.Http.OData/OData/Query/SkipQueryOption.cs
+++ b/OData/src/System.Web.Http.OData/OData/Query/SkipQueryOption.cs
@@ -136,7 +136,7 @@ namespace System.Web.Http.OData.Query
         /// <returns></returns>
         public IQueryable<TSource> Translate<TSource>(IQueryable<TSource> result, ODataQuerySettings querySettings)
         {
-            return result;
+            return result.Skip(Value);
         }
     }
 }

--- a/OData/src/System.Web.Http.OData/OData/Query/TopQueryOption.cs
+++ b/OData/src/System.Web.Http.OData/OData/Query/TopQueryOption.cs
@@ -136,7 +136,7 @@ namespace System.Web.Http.OData.Query
         /// <returns></returns>
         public IQueryable<TSource> Translate<TSource>(IQueryable<TSource> result, ODataQuerySettings querySettings)
         {
-            return result;
+            return result.Take(Value);
         }
     }
 }

--- a/OData/src/System.Web.Http.OData/OData/Query/Translator/ExpressionTranslator.cs
+++ b/OData/src/System.Web.Http.OData/OData/Query/Translator/ExpressionTranslator.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 using System.Web.Http.OData.Query.Translator;
 using Microsoft.Data.Edm;
@@ -34,6 +35,13 @@ namespace System.Web.Http.OData.Query
             var model = GetEdmModel();
             var type = _queryTranslator.GetEdmType<TSource, TDestination>();
             return ODataUriParser.ParseOrderBy(translatedExpression, model, type);
+        }
+
+        public IEdmProperty TranslateProperty(IEdmProperty property)
+        {
+            var fieldName = _queryTranslator.TranslateField<TSource, TDestination>(property.Name);
+            var type = _queryTranslator.GetEdmType<TSource, TDestination>() as IEdmEntityType;
+            return type.DeclaredProperties.SingleOrDefault(p => p.Name == fieldName);
         }
 
         private string GetTranslatedExpression(OrderByClause expression)


### PR DESCRIPTION
### Issues
Fixes null reference exceptions when using $top without $orderby
Fixes $skip and $take option not applying to result

### Description
Ensured that _queryTranslator was passed to OrderByQueryOption
Ensured that property is translated before calling OrderByProperty
Applied Take and Skip to result
